### PR TITLE
Apk whitespace removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sputnik changelog
 
-### 0.9.0 - ??-??-????
+### 0.9.0 - 08-06-2017
 * whitespaces in apk base filename replaced with a dash
 
 ### 0.8.1 - 06-06-2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Sputnik changelog
+
+### 0.9.0 - ??-??-????
+* whitespaces in apk base filename replaced with a dash
+
 ### 0.8.1 - 06-06-2017
 * Remove 'UnusedResources' error warning.
 * Move to Wercker build/deploys

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION = 0.8.1
+VERSION = 0.9.0
 DISPLAY_NAME=Sputnik
 ARTIFACT_ID=sputnik
 ORG=tapadoo

--- a/sputnik/src/main/kotlin/com/tapadoo/sputnik/options/FileOutputOptions.kt
+++ b/sputnik/src/main/kotlin/com/tapadoo/sputnik/options/FileOutputOptions.kt
@@ -68,7 +68,8 @@ class FileOutputOptions(val project: Project) {
             template = nameFormat
         }
 
-        val fileName = templateEngine.createTemplate(template).make(map).toString()
+        val whitespacePattern = "\\s".toRegex()
+        val fileName = templateEngine.createTemplate(template).make(map).toString().replace(whitespacePattern,"-")
         project.setProperty("archivesBaseName", fileName)
     }
 }


### PR DESCRIPTION
Spaces in file names can cause issues with other tools. Might be best to continue allowing them in project names or wherever, but remove them from apk output file name.
Bumped version to 0.9 also.